### PR TITLE
Rate limit using JSON fields only

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ The `rules` section is a dictionary where the keys are the rule names which are 
 - `pod_labels` is a dicionary of labels to be matched, matching containers will be watched
 - `regex` is a regular expression that matches logs that should be sent to Zulip
 
-Optionally enable rate limiting (limits apply per rule):
+### JSON logs
 
-- `group_regex`: Regular expression that contains one (subgroup) which will be used to group logs for rate limiting purposes
+If logs are in JSON format they will be autoformatted when sent to Zulip.
+JSON logs support optional rate limiting.
+Limits apply per rule:
+
+- `json_grouping_fields`: List of JSON keys whose values are joined to form a string that is used to group logs for rate-limiting
 - `limit_first_n`: Rate limiter bucket size, show this number of logs initially
 - `limit_interval_seconds`: Rate limits alerts to this interval between alerts
 - `limit_reset_seconds`: Reset the limiter if there are no alerts for this time period

--- a/config.json
+++ b/config.json
@@ -11,8 +11,11 @@
         "app.kubernetes.io/name": "cryptnono"
       },
       "regex": "\"action\":\\s*\"killed\"",
-      "_comment": "Group by pod name, limit to 1/minute but allow initial burst of 4, reset after 10 minutes",
-      "group_regex": "\"io.kubernetes.pod.name\":\\s*\"([^\"]+)\"",
+      "_comment": "Group by (pod name + matched string), limit to 1/minute but allow initial burst of 4, reset after 10 minutes",
+      "json_grouping_fields": [
+        "labels.io\\.kubernetes\\.pod\\.name",
+        "matched"
+      ],
       "limit_first_n": 4,
       "limit_interval_seconds": 60,
       "limit_reset_seconds": 600

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/prometheus/client_golang v1.23.2
+	github.com/tidwall/gjson v1.18.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/time v0.14.0
 	k8s.io/api v0.35.0
@@ -43,6 +44,8 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,12 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -27,8 +27,10 @@ rules: {}
   #   pod_labels:
   #     app.kubernetes.io/name: cryptnono
   #   regex: "\"action\":\\s*\"killed\""
-  #   # Group by pod name, limit to 1/minute but allow initial burst of 4, reset after 10 minutes",
-  #   group_regex: "\"io.kubernetes.pod.name\":\\s*\"([^\"]+)\""
+  #   # Group by pod name and match, limit to 1/minute but allow initial burst of 4, reset after 10 minutes
+  #   json_grouping_fields:
+  #     - "labels.io\\.kubernetes\\.pod\\.name"
+  #     - "matched"
   #   limit_first_n: 4
   #   limit_interval_seconds: 60
   #   limit_reset_seconds: 600

--- a/internal/logwatch.go
+++ b/internal/logwatch.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/tidwall/gjson"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,7 +22,7 @@ import (
 
 // Rule describes a rule for matching logs and sending alerts
 // If rate-limiting is enabled:
-// - GroupRegex is a regex containing a (subgroup) that is used to group logs for rate-limiting
+// - JsonGroupingFields is a list of JSON keys whose values are joined to form a string that is used to group logs for rate-limiting
 // - LimitFirstN will always alert on the first N logs
 // - LimitIntervalSeconds is the minimum number of seconds between each subsequent alert
 // - LimitResetSeconds is approximately when the rate limiter will be reset
@@ -29,8 +31,7 @@ type Rule struct {
 	PodLabels            map[string]string `json:"pod_labels"`
 	Regex                string            `json:"regex"`
 	Compiled             *regexp.Regexp    `json:"-"`
-	GroupRegex           string            `json:"group_regex"`
-	CompiledGroup        *regexp.Regexp    `json:"-"`
+	JsonGroupingFields   []string          `json:"json_grouping_fields"`
 	LimitFirstN          int               `json:"limit_first_n"`
 	LimitIntervalSeconds int               `json:"limit_interval_seconds"`
 	LimitResetSeconds    int               `json:"limit_reset_seconds"`
@@ -44,15 +45,10 @@ func (r *Rule) Init(name string) error {
 
 	re := regexp.MustCompile(r.Regex)
 
-	var gre *regexp.Regexp
-	if len(r.GroupRegex) > 0 {
-		gre = regexp.MustCompile(r.GroupRegex)
-	}
-
 	if r.LimitFirstN > 0 || r.LimitIntervalSeconds > 0 {
-		if gre == nil {
+		if len(r.JsonGroupingFields) == 0 {
 			return fmt.Errorf(
-				"group_regex is required in rule %s since rate limits are enabled",
+				"json_grouping_fields is required in rule %s since rate limits are enabled",
 				name,
 			)
 		}
@@ -66,7 +62,6 @@ func (r *Rule) Init(name string) error {
 
 	r.Name = name
 	r.Compiled = re
-	r.CompiledGroup = gre
 	return nil
 }
 
@@ -219,7 +214,7 @@ func RunWatcher(
 
 // getRateLimiter creates the rate limiter for this rule if enabled
 func getRateLimiter(ctx context.Context, rule *Rule) (*TTLCache[*rate.Limiter], error) {
-	if rule.CompiledGroup != nil {
+	if len(rule.JsonGroupingFields) > 0 {
 		ttl := time.Duration(rule.LimitResetSeconds) * time.Second
 		pruneInterval := ttl / 10
 		rateLimiter, err := NewTTLCache(
@@ -349,11 +344,7 @@ func evaluateRule(
 	if rule.Compiled.MatchString(line) {
 		key := ""
 		if rateLimiter != nil {
-			// Look for the first regex (group) match
-			matches := rule.CompiledGroup.FindStringSubmatch(line)
-			if len(matches) > 1 {
-				key = matches[1]
-			}
+			key = getGroupingKey(rule, line)
 		}
 
 		metrics.LogsAlertsTotal.Inc()
@@ -375,4 +366,37 @@ func evaluateRule(
 		}
 	}
 	return err
+}
+
+// getGroupingKey looks up JSON fields, and concatenates them using ASCII 0x1F
+// (Unit Separator).
+// Missing fields are set to ""
+// If line is not valid JSON returns ""
+// If all fields are empty or missing returns ""
+func getGroupingKey(rule *Rule, line string) string {
+	const delimiter = "\x1f"
+
+	if !gjson.Valid(line) {
+		// TODO: log warning
+		return ""
+	}
+	var values []string
+	for _, jsonKey := range rule.JsonGroupingFields {
+		result := gjson.Get(line, jsonKey)
+		values = append(values, result.String())
+	}
+
+	allEmpty := true
+	for _, v := range values {
+		if v != "" {
+			allEmpty = false
+			break
+		}
+	}
+
+	if allEmpty {
+		return ""
+	}
+
+	return strings.Join(values, delimiter)
 }

--- a/internal/logwatch_test.go
+++ b/internal/logwatch_test.go
@@ -278,10 +278,9 @@ func TestEvaluateRule(t *testing.T) {
 	}
 
 	rule := &Rule{
-		PodLabels: map[string]string{"app": "test"},
-		Regex:     "\\[test\\]",
-		// The first (group) is used as the key
-		GroupRegex: "^(g[\\d])-\\w",
+		PodLabels:          map[string]string{"app": "test"},
+		Regex:              "\\[test\\]",
+		JsonGroupingFields: []string{"group"},
 	}
 	if err := rule.Init("Test Rule"); err != nil {
 		t.Fatal(err)
@@ -303,25 +302,36 @@ func TestEvaluateRule(t *testing.T) {
 	}
 
 	metrics := NewLogwatchMetrics(prometheus.NewRegistry(), "test")
-	testStrings := []string{
-		"[no match]",
+
+	type testData struct {
+		group string
+		msg   string
+	}
+
+	testItems := []testData{
+		{"g1", "[no match]"},
+		// Empty group
+		{"", "a [test]"},
+		{"", "b [test]"},
+		{"", "c [test]"},
 		// Group g1
-		"g1-a [test]",
-		"g1-b [test]",
-		"g1-c [test]",
+		{"g1", "g1-a [test]"},
+		{"g1", "g1-b [test]"},
+		{"g1", "g1-c [test]"},
 		// Group g2
-		"g2-a [test]",
+		{"g2", "g2-a [test]"},
 	}
 
 	for i := range 3 {
 		time.Sleep(500 * time.Millisecond)
-		for _, mark := range testStrings {
+		for _, item := range testItems {
+			line := fmt.Sprintf(`{"group": "%s", "msg": "%s %d"}`, item.group, item.msg, i)
 			err := evaluateRule(
 				t.Context(),
 				rule,
 				rateLimiter,
 				alerter,
-				fmt.Sprintf("%s %d", mark, i),
+				line,
 				pod,
 				&pod.Spec.Containers[0],
 				metrics,
@@ -335,13 +345,14 @@ func TestEvaluateRule(t *testing.T) {
 
 	// This should be enough to reset the limiter, so burst=2 should take effect again
 	time.Sleep(2 * time.Second)
-	for _, mark := range testStrings {
+	for _, item := range testItems {
+		line := fmt.Sprintf(`{"group": "%s", "msg": "%s 😀"}`, item.group, item.msg)
 		err := evaluateRule(
 			t.Context(),
 			rule,
 			rateLimiter,
 			alerter,
-			fmt.Sprintf("%s 😀", mark),
+			line,
 			pod,
 			&pod.Spec.Containers[0],
 			metrics,
@@ -351,7 +362,9 @@ func TestEvaluateRule(t *testing.T) {
 		}
 	}
 
-	// Regex 'g[1-3]' defines the group identifiers used for rate limiting
+	// The 'group' field provides the group identifiers used for rate limiting
+	//
+	// A match with empty group is never rate limited
 	//
 	// The rate limit is 1/s, but with Burst=2 so "g1-a [test]" and "g1-b [test]"
 	// should appear the first time
@@ -365,27 +378,43 @@ func TestEvaluateRule(t *testing.T) {
 	expected_messages := []string{
 		// "[no match]", never matches
 
-		"g1-a [test] 0",
-		"g1-b [test] 0",
+		`{"group": "", "msg": "a [test] 0"}`,
+		`{"group": "", "msg": "b [test] 0"}`,
+		`{"group": "", "msg": "c [test] 0"}`,
+
+		`{"group": "g1", "msg": "g1-a [test] 0"}`,
+		`{"group": "g1", "msg": "g1-b [test] 0"}`,
 		// "g1-c [test] 0", rate limited
-		"g2-a [test] 0",
+		`{"group": "g2", "msg": "g2-a [test] 0"}`,
+
+		`{"group": "", "msg": "a [test] 1"}`,
+		`{"group": "", "msg": "b [test] 1"}`,
+		`{"group": "", "msg": "c [test] 1"}`,
 
 		// "g1-a [test] 1", rate limited
 		// "g1-b [test] 1", rate limited
 		// "g1-c [test] 1", rate limited
-		"g2-a [test] 1",
+		`{"group": "g2", "msg": "g2-a [test] 1"}`,
 
-		"g1-a [test] 2",
+		`{"group": "", "msg": "a [test] 2"}`,
+		`{"group": "", "msg": "b [test] 2"}`,
+		`{"group": "", "msg": "c [test] 2"}`,
+
+		`{"group": "g1", "msg": "g1-a [test] 2"}`,
 		// "g1-b [test] 2", rate limited
 		// "g1-c [test] 2", rate limited
-		"g2-a [test] 2",
+		`{"group": "g2", "msg": "g2-a [test] 2"}`,
 
 		// 2s delay means the limits are reset
 
-		"g1-a [test] 😀",
-		"g1-b [test] 😀",
+		`{"group": "", "msg": "a [test] 😀"}`,
+		`{"group": "", "msg": "b [test] 😀"}`,
+		`{"group": "", "msg": "c [test] 😀"}`,
+
+		`{"group": "g1", "msg": "g1-a [test] 😀"}`,
+		`{"group": "g1", "msg": "g1-b [test] 😀"}`,
 		// "g1-c [test] 😀", rate limited
-		"g2-a [test] 😀",
+		`{"group": "g2", "msg": "g2-a [test] 😀"}`,
 	}
 	if len(expected_messages) != len(alerter.messages) {
 		t.Fatalf(
@@ -399,5 +428,75 @@ func TestEvaluateRule(t *testing.T) {
 		if message != expected_messages[idx] {
 			t.Errorf("[%d] Expected alert '%s', got '%s'", idx, expected_messages[idx], message)
 		}
+	}
+}
+
+func TestGetGroupingKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		fields   []string
+		line     string
+		expected string
+	}{
+		{
+			name:     "Single field exists",
+			fields:   []string{"a"},
+			line:     `{"a": "val"}`,
+			expected: "val",
+		},
+		{
+			name:     "Multiple fields exist",
+			fields:   []string{"a", "b"},
+			line:     `{"a": "val1", "b": "val2"}`,
+			expected: "val1\x1fval2",
+		},
+		{
+			name:     "Some fields missing",
+			fields:   []string{"a", "c"},
+			line:     `{"a": "val1", "b": "val2"}`,
+			expected: "val1\x1f",
+		},
+		{
+			name:     "Nested fields",
+			fields:   []string{"a.b"},
+			line:     `{"a": {"b": "val"}}`,
+			expected: "val",
+		},
+		{
+			name:     "All fields missing",
+			fields:   []string{"c"},
+			line:     `{"a": "val"}`,
+			expected: "",
+		},
+		{
+			name:     "Invalid JSON",
+			fields:   []string{"a"},
+			line:     `not json`,
+			expected: "",
+		},
+		{
+			name:     "Empty values",
+			fields:   []string{"a", "b"},
+			line:     `{"a": "", "b": ""}`,
+			expected: "",
+		},
+		{
+			name:     "Mixed empty and non-empty",
+			fields:   []string{"a", "b"},
+			line:     `{"a": "val", "b": ""}`,
+			expected: "val\x1f",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := &Rule{
+				JsonGroupingFields: tt.fields,
+			}
+			got := getGroupingKey(rule, tt.line)
+			if got != tt.expected {
+				t.Errorf("getGroupingKey() = %q, expected %q", got, tt.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Replaces the regex grouping added in https://github.com/manics/k8s-log-alerter-zulip/pull/6 with JSON field lookups